### PR TITLE
Fixing method name mismatch

### DIFF
--- a/isJailbroken/ViewController.m
+++ b/isJailbroken/ViewController.m
@@ -22,7 +22,7 @@
 @implementation ViewController
 - (void)viewDidLoad {
     [super viewDidLoad];
-    BOOL securityCheckResult = isSecurityCheckNotPassed();
+    BOOL securityCheckResult = isSecurityCheckPassed();
     BOOL appStoreResult = isFromAppStore();
     BOOL debugResult = isDebugged();
     BOOL dylibResult = isInjectedWithDynamicLibrary();


### PR DESCRIPTION
methods name on JB.h/m was renamed from `isSecurityCheckNotPassed ` to `isSecurityCheckPassed ` on this commit https://github.com/avltree9798/isJailbroken/commit/7d398a0d140fa803b0d79e4bc370e63f0086499f.

But the view controller reference wasn't renamed appropriately. This PR will rectify that.
